### PR TITLE
Add's support for passing custom closure into compute_loss function for custom models #1

### DIFF
--- a/losscape/compute_loss.py
+++ b/losscape/compute_loss.py
@@ -28,7 +28,17 @@ def compute_loss(model, train_loader_unshuffled, get_batch, criterion = F.cross_
 
     if train_loader_unshuffled is not None:
         with torch.no_grad():
-            loss, batch_idx = closure(train_loader_unshuffled,num_batches)
+            if closure is not None:
+                loss, batch_idx = closure(train_loader_unshuffled,num_batches)
+            else:
+                for batch_idx, (Xb, Yb) in enumerate(train_loader_unshuffled):
+                    Xb, Yb = Xb.to(device), Yb.to(device)
+    
+                    logits = model(Xb)
+                    loss += criterion(logits, Yb).item()
+
+                    if batch_idx + 1 >= num_batches:
+                        break
     
         loss = loss / (batch_idx + 1)
     else:

--- a/losscape/compute_loss.py
+++ b/losscape/compute_loss.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-def compute_loss(model, train_loader_unshuffled, get_batch, criterion = F.cross_entropy, num_batches:int = 8):
+def compute_loss(model, train_loader_unshuffled, get_batch, criterion = F.cross_entropy, num_batches:int = 8,closure = None):
     """
     Compute and return the loss over the first num_batches batches given by the train_loader_unshuffled, using the criterion provided.
 
@@ -14,7 +14,7 @@ def compute_loss(model, train_loader_unshuffled, get_batch, criterion = F.cross_
     train_loader_unshuffled : the torch dataloader. It is supposed to be fixed so that all the calls to this function will use the same data.
     criterion : the criterion used to compute the loss. (default to F.cross_entropy)
     num_batches : number of batches to evaluate the model with. (default to 8)
-
+    closure : An optional closure that can be passed in. This can be used if your model takes non-standard inputs or provides non-standard outputs.
     Returns
     ----------
     loss : loss computed
@@ -28,14 +28,7 @@ def compute_loss(model, train_loader_unshuffled, get_batch, criterion = F.cross_
 
     if train_loader_unshuffled is not None:
         with torch.no_grad():
-            for batch_idx, (Xb, Yb) in enumerate(train_loader_unshuffled):
-                Xb, Yb = Xb.to(device), Yb.to(device)
-
-                logits = model(Xb)
-                loss += criterion(logits, Yb).item()
-
-                if batch_idx + 1 >= num_batches:
-                    break
+            loss = closure(train_loader_unshuffled,num_batches)
     
         loss = loss / (batch_idx + 1)
     else:

--- a/losscape/compute_loss.py
+++ b/losscape/compute_loss.py
@@ -28,7 +28,7 @@ def compute_loss(model, train_loader_unshuffled, get_batch, criterion = F.cross_
 
     if train_loader_unshuffled is not None:
         with torch.no_grad():
-            loss = closure(train_loader_unshuffled,num_batches)
+            loss, batch_idx = closure(train_loader_unshuffled,num_batches)
     
         loss = loss / (batch_idx + 1)
     else:

--- a/losscape/create_landscape.py
+++ b/losscape/create_landscape.py
@@ -16,7 +16,7 @@ from losscape.create_directions import create_random_direction, create_random_di
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, direction=None, criterion = None, num_batches:int = 8, save_only:bool = False, output_path:str = '', x_min:float=-1., x_max:float=1., num_points:int=50):
+def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, direction=None, criterion = None, closure = None, num_batches:int = 8, save_only:bool = False, output_path:str = '', x_min:float=-1., x_max:float=1., num_points:int=50):
     """
     Create a 2D losscape of the given model.
 
@@ -32,6 +32,7 @@ def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
     x_min : min x value (that multiply the sampled direction). (default to -1.) 
     x_max : max x value (that multiply the sampled direction). (default to 1.)
     num_points : number of points to evaluate the loss, from x_min to x_max. (default to 50)
+    closure: Here you can provide a custom closure that will be used to compute the loss. One common use case is if your model provides non standard outputs or non standard inputs
 
     Returns
     ----------
@@ -53,7 +54,7 @@ def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
     for x in coords:
         _set_weights(model, init_weights, direction, x)
 
-        loss = compute_loss(model, train_loader_unshuffled, get_batch, criterion, num_batches)
+        loss = compute_loss(model, train_loader_unshuffled, get_batch, criterion, num_batches, closure = closure)
         losses.append(loss)
 
     _reset_weights(model, init_weights)

--- a/losscape/create_landscape.py
+++ b/losscape/create_landscape.py
@@ -26,13 +26,13 @@ def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
     train_loader_unshuffled : the torch dataloader. It is supposed to be fixed so that all the calls to this function will use the same data.
     optimizer : the optimizer used for training (should follow the same API as torch optimizers).(default to Adam)
     criterion : the criterion used to compute the loss. (default to F.cross_entropy)
+    closure : an optional closure that will replace the default compute_loss internals
     num_batches : number of batches to evaluate the model with. (default to 8)
     save_only : only save the plot and don't display it. (default to False)
     output_path : path where the plot will be saved. (default to '2d_losscape.png')
     x_min : min x value (that multiply the sampled direction). (default to -1.) 
     x_max : max x value (that multiply the sampled direction). (default to 1.)
     num_points : number of points to evaluate the loss, from x_min to x_max. (default to 50)
-    closure: Here you can provide a custom closure that will be used to compute the loss. One common use case is if your model provides non standard outputs or non standard inputs
 
     Returns
     ----------
@@ -69,7 +69,7 @@ def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
 
     return coords, losses
 
-def create_3D_losscape(model, train_loader_unshuffled=None, get_batch=None, directions=None, criterion = None, num_batches:int = 8, save_only:bool = False, output_path:str = '', output_vtp:bool = True, output_h5:bool = True, x_min:float=-1., x_max:float=1., y_min:float=-1., y_max:float=1., num_points:int=50):
+def create_3D_losscape(model, train_loader_unshuffled=None, get_batch=None, directions=None, criterion = None, closure = None, num_batches:int = 8, save_only:bool = False, output_path:str = '', output_vtp:bool = True, output_h5:bool = True, x_min:float=-1., x_max:float=1., y_min:float=-1., y_max:float=1., num_points:int=50):
     """
     Create a 3D losscape of the given model.
 
@@ -79,6 +79,7 @@ def create_3D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
     train_loader_unshuffled : the torch dataloader. It is supposed to be fixed so that all the calls to this function will use the same data.
     optimizer : the optimizer used for training (should follow the same API as torch optimizers).(default to Adam)
     criterion : the criterion used to compute the loss. (default to F.cross_entropy)
+    closure : an optional closure that will replace the default compute_loss internals
     num_batches : number of batches to evaluate the model with. (default to 8)
     save_only : only save the plot and don't display it. (default to False)
     output_path : path where the plot will be saved. (default to '3d_losscape.png')
@@ -119,7 +120,7 @@ def create_3D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
         for j in range(X.shape[1]):
             _set_weights(model, init_weights, directions, np.array([X[i, j], Y[i, j]]))
 
-            loss = compute_loss(model, train_loader_unshuffled, get_batch, criterion, num_batches)
+            loss = compute_loss(model, train_loader_unshuffled, get_batch, criterion, num_batches, closure = closure)
             losses[i, j] = loss
 
             count += 1

--- a/losscape/create_landscape.py
+++ b/losscape/create_landscape.py
@@ -16,7 +16,7 @@ from losscape.create_directions import create_random_direction, create_random_di
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, direction=None, criterion = None, num_batches:int = 8, save_only:bool = False, output_path:str = '', x_min:float=-1., x_max:float=1., num_points:int=50):
+def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, direction=None, criterion = None, closure = None, num_batches:int = 8, save_only:bool = False, output_path:str = '', x_min:float=-1., x_max:float=1., num_points:int=50):
     """
     Create a 2D losscape of the given model.
 
@@ -26,6 +26,7 @@ def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
     train_loader_unshuffled : the torch dataloader. It is supposed to be fixed so that all the calls to this function will use the same data.
     optimizer : the optimizer used for training (should follow the same API as torch optimizers).(default to Adam)
     criterion : the criterion used to compute the loss. (default to F.cross_entropy)
+    closure : an optional closure that will replace the default compute_loss internals
     num_batches : number of batches to evaluate the model with. (default to 8)
     save_only : only save the plot and don't display it. (default to False)
     output_path : path where the plot will be saved. (default to '2d_losscape.png')
@@ -53,7 +54,7 @@ def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
     for x in coords:
         _set_weights(model, init_weights, direction, x)
 
-        loss = compute_loss(model, train_loader_unshuffled, get_batch, criterion, num_batches)
+        loss = compute_loss(model, train_loader_unshuffled, get_batch, criterion, num_batches, closure = closure)
         losses.append(loss)
 
     _reset_weights(model, init_weights)
@@ -68,7 +69,7 @@ def create_2D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
 
     return coords, losses
 
-def create_3D_losscape(model, train_loader_unshuffled=None, get_batch=None, directions=None, criterion = None, num_batches:int = 8, save_only:bool = False, output_path:str = '', output_vtp:bool = True, output_h5:bool = True, x_min:float=-1., x_max:float=1., y_min:float=-1., y_max:float=1., num_points:int=50):
+def create_3D_losscape(model, train_loader_unshuffled=None, get_batch=None, directions=None, criterion = None, closure = None, num_batches:int = 8, save_only:bool = False, output_path:str = '', output_vtp:bool = True, output_h5:bool = True, x_min:float=-1., x_max:float=1., y_min:float=-1., y_max:float=1., num_points:int=50):
     """
     Create a 3D losscape of the given model.
 
@@ -78,6 +79,7 @@ def create_3D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
     train_loader_unshuffled : the torch dataloader. It is supposed to be fixed so that all the calls to this function will use the same data.
     optimizer : the optimizer used for training (should follow the same API as torch optimizers).(default to Adam)
     criterion : the criterion used to compute the loss. (default to F.cross_entropy)
+    closure : an optional closure that will replace the default compute_loss internals
     num_batches : number of batches to evaluate the model with. (default to 8)
     save_only : only save the plot and don't display it. (default to False)
     output_path : path where the plot will be saved. (default to '3d_losscape.png')
@@ -118,7 +120,7 @@ def create_3D_losscape(model, train_loader_unshuffled=None, get_batch=None, dire
         for j in range(X.shape[1]):
             _set_weights(model, init_weights, directions, np.array([X[i, j], Y[i, j]]))
 
-            loss = compute_loss(model, train_loader_unshuffled, get_batch, criterion, num_batches)
+            loss = compute_loss(model, train_loader_unshuffled, get_batch, criterion, num_batches, closure = closure)
             losses[i, j] = loss
 
             count += 1


### PR DESCRIPTION
This PR adds support for passing a closure into the `compute_loss` function that will be run in lieu of the normal data load iterator. This makes it easier to integrate custom models that have non-standard outputs and/or non-standard inputs. 

## Example:
```python
def closure(loader,num_batches):
  loss = 0
  for batch_idx, (prot_emb, mol_emb, labels) in enumerate(loader):
    labels = labels[0]

    prot_emb = prot_emb.cuda()
    mol_emb = mol_emb.cuda()

    labels = labels.cuda()

    logits = model(prot_emb,mol_emb)
    loss += F.binary_cross_entropy_with_logits(logits, labels).item()

    if batch_idx + 1 >= num_batches:
        break
  return loss, batch_idx
```